### PR TITLE
Add rsync binary

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -29,6 +29,7 @@ RUN \
     sudo \
     tzdata \
     cargo \
+    rsync \
     1password-cli \
     # install gosu for a better su+exec command (remove sudo if this works)
     && wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-amd64" \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -38,6 +38,7 @@ RUN \
     curl \
     tzdata \
     cargo \
+    rsync \
     1password-cli \
     # install gosu for a better su+exec command (remove sudo if this works)
     && wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-amd64" \


### PR DESCRIPTION
Work around this problem:

https://drone-ci.quiknode.net/quiknode-labs/role-elastic-heartbeat/6/1/2

```
TASK [role-elastic-heartbeat : Synchronize monitors.d files] *******************
fatal: [synthetics-iad-01]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"rsync\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
```